### PR TITLE
field value looping if #define ONLY_UP_KEY

### DIFF
--- a/src/menuFields.h
+++ b/src/menuFields.h
@@ -76,7 +76,11 @@ v2.0 - 	Calling action on every elements
 		}
 		void clamp() {
       if (value<low) value=low;
+#ifdef ONLY_UP_KEY
+      else if (value>high) value=low;
+#else
       else if (value>high) value=high;
+#endif
 		}
 		//lazy drawing, we have no drawing position here... so we will ask the menu to redraw
 		virtual promptFeedback activate(menuOut& p,Stream&c,bool canExit=false) {


### PR DESCRIPTION
I you have only 2 keys in your device you can't change values in FIELDs cause you can't go down after maximum value. So, we can change clamp() function with ONLY_UP_KEY definition.

```
void clamp() {
      if (value<low) value=low;
#ifdef ONLY_UP_KEY
      else if (value>high) value=low;
#else
      else if (value>high) value=high;
#endif
}
```