### PR TITLE
Added #ifdef DEBUG to comment out more << operators.

### DIFF
--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -86,10 +86,12 @@ void menuOut::doNav(navCmd cmd,navNode &nav) {
   }
 }
 
+#ifdef DEBUG
 menuOut& menuOut::operator<<(const prompt& p) {
   print_P(*this,p.getText());
   return *this;
 }
+#endif
 
 void menuOut::clearChanged(navNode &nav) {
   //if (nav.target->dirty) Serial<<"clear dirty "<<*(prompt*)nav.target<<" sz:"<<nav.sz()<<endl;

--- a/src/menu.h
+++ b/src/menu.h
@@ -35,11 +35,13 @@ www.r-site.net
 
     // Streams
     //////////////////////////////////////////////////////////////////////////
+    #ifdef DEBUG
     //template<typename T> inline Print& operator<<(Print& o, T t) {o.print(t);return o;}
     Print& operator<<(Print& o,prompt const &p);
     inline String& operator<<(String &s,prompt &p);
     //template<typename T> HardwareSerial& operator<<(HardwareSerial& o,T t) {o.print(t);return o;}
     //template<typename T> inline menuOut& operator<<(menuOut& o,const T x) {return o.operator<<(x);}
+    #endif
 
     // Menu objects and data
     //////////////////////////////////////////////////////////////////////////
@@ -316,9 +318,11 @@ www.r-site.net
         inline idx_t maxY(idx_t i=0) const {return panels[i].h;}
         inline idx_t& top(navNode& nav) const;
         idx_t printRaw(const char* at,idx_t len);
+        #ifdef DEBUG
         virtual menuOut& operator<<(prompt const &p);
         #ifdef ESP8266
         template<typename T> menuOut& operator<<(T o) {(*(Print*)this)<<(o);return *this;}
+        #endif
         #endif
         virtual menuOut& fill(
           int x1, int y1, int x2, int y2,char ch=' ',
@@ -676,7 +680,9 @@ www.r-site.net
 
     idx_t& menuOut::top(navNode& nav) const {return tops[nav.root->level];}
 
+    #ifdef DEBUG
     inline String& operator<<(String &s,prompt &p) {return s+=p.getText();}
+    #endif
   }//namespace Menu
 
 #endif

--- a/src/menuBase.cpp
+++ b/src/menuBase.cpp
@@ -29,10 +29,12 @@ navCmds Menu::getCmd(String &name) {
   return noCmd;
 }*/
 
+#ifdef DEBUG
 Print& Menu::operator<<(Print& o,prompt const &p) {
   print_P(o,p.getText());
   return o;
 }
+#endif
 
 const navCodesDef Menu::defaultNavCodes={
   {noCmd,(char)0xff},


### PR DESCRIPTION
It looks like the `<<` operator is only used during debugging (`#define DEBUG`). This pull request adds some missing `#ifdef DEBUG ... #endif` to remove all references to the `<<` operator, if no debugging is required. This saves 38 bytes of program storage space #106.