### PR TITLE
Rewrite peek function to use if/else instead of ?: statement

### DIFF
--- a/src/menuIO/keypadIn.h
+++ b/src/menuIO/keypadIn.h
@@ -22,7 +22,20 @@ using
       Keypad& in;
       keypadIn(Keypad& in):in(in) {}
       int available(void) {return peek()!=0;}
-      int peek(void) {return key?key:(key=in.getKey()?key:-1);}
+      int peek(void) {
+        int ret;
+
+        if (key) {
+          return key;
+        } else {
+          key = (int)in.getKey();
+          if (key) {
+            return key;
+          } else {
+            return -1;
+          }
+        }
+      }
       int read() {
         if (key) {
           char k=key;


### PR DESCRIPTION
Original version didn't work form me.
I was testing it on Nucleo F091RC and I wasn't able to use keypad.
I was debugging in this way: 
```
ret = key?key:(key=in.getKey()?key:-1);
Serial.println(key, HEX);
return ret;
```
and key hasn't been assigned to value returned by `getKey`. (I was also printing return value from inside of `getKey` to be make sure that it is returning something...)

In this way it works as expected. 