### PR TITLE
Button Navigation example sketch for SSD1306Ascii

### DIFF
--- a/examples/SSD1306Ascii/Button_Navigation/OLED_&_BTN_NAV.ino
+++ b/examples/SSD1306Ascii/Button_Navigation/OLED_&_BTN_NAV.ino
@@ -1,0 +1,232 @@
+/**************************************************************************
+* Sketch: MENU NAVIGATION WITH JUST 3 BUTTONS
+*
+* This Sketch displays Menu without any Serial Communication and the
+* navigation is performed by 3 buttons attached to D6, D7, D8.
+* Also, attach led on D11 to control brightness from menu. 
+* Default brightness is 15% (check line 78)
+*  
+*  NOTE: By default, navigation buttons use INTERNAL_PULLUP feature.
+*        This can be changed by commenting the line 45 in "config.h" file
+*        
+*  Uses SSD1306Ascii Library(https://github.com/greiman/SSD1306Ascii)
+*  by Bill Grieman
+*
+*  Modifed by Tamojit Saha(https://github.com/TamojitSaha)
+*  August 19, 2018
+***************************************************************************/
+#include <Arduino.h>
+
+// #include <Wire.h>
+#include "SSD1306Ascii.h"
+#include "SSD1306AsciiWire.h"
+
+#include <menu.h>
+#include <menuIO/SSD1306AsciiOut.h>
+#include <menuIO/keyIn.h>
+//#include <menuIO/chainStream.h>
+using namespace Menu;
+
+SSD1306AsciiWire oled;
+
+#include "config.h"
+
+int ledCtrl = HIGH;  //Default LED State of LED at D11 is LOW
+
+result doAlert(eventMask e, prompt &item);
+
+result showEvent(eventMask e, navNode& nav, prompt& item) {
+
+  return proceed;
+}
+
+
+
+result action1(eventMask e) {
+
+  return proceed;
+}
+
+result action2(eventMask e, navNode& nav, prompt &item) {
+  //Serial.print(e);
+  //Serial.println(" action2 executed, quiting menu");
+  return quit;
+}
+
+
+result ledOn() {
+  ledCtrl = HIGH;
+  analogWrite(LED_PIN, 255);
+  return proceed;
+}
+result ledOff() {
+  ledCtrl = LOW;
+  analogWrite(LED_PIN, 0);
+  return proceed;
+}
+
+
+result internalLedOn() {
+  digitalWrite(LED_BUILTIN, HIGH);
+  return proceed;
+}
+result internalLedOff() {
+  analogWrite(LED_BUILTIN, LOW);
+  return proceed;
+}
+
+int brightnessValue = 15;   //Default LED brightness value
+result adjustBrightness() {
+  if (ledCtrl == HIGH) {
+    int pwm = int(2.55 * float(brightnessValue));
+    Serial.println("Brightness: " + String(brightnessValue));
+    Serial.println("PWM: " + String(pwm));
+    analogWrite(LED_PIN, pwm);
+  }
+  else {
+
+  }
+}
+
+
+TOGGLE(ledCtrl, setLed, "Led: ", doNothing, noEvent, noStyle //,doExit,enterEvent,noStyle
+       , VALUE("On", HIGH, ledOn, enterEvent)//ledOn function is called
+       , VALUE("Off", LOW, ledOff, enterEvent)//ledOff function is called
+      );
+
+int selTest = 0;
+SELECT(selTest, selMenu, "Select", doNothing, noEvent, noStyle
+       , VALUE("Zero", 0, doNothing, noEvent)
+       , VALUE("One", 1, doNothing, noEvent)
+       , VALUE("Two", 2, doNothing, noEvent)
+      );
+
+int chooseTest = -1;
+CHOOSE(chooseTest, chooseMenu, "Choose", doNothing, noEvent, noStyle
+       , VALUE("First", 1, doNothing, noEvent)
+       , VALUE("Second", 2, doNothing, noEvent)
+       , VALUE("Third", 3, doNothing, noEvent)
+       , VALUE("Last", -1, doNothing, noEvent)
+      );
+
+//customizing a prompt look!
+//by extending the prompt class
+class altPrompt: public prompt {
+  public:
+    altPrompt(constMEM promptShadow& p): prompt(p) {}
+    Used printTo(navRoot &root, bool sel, menuOut& out, idx_t idx, idx_t len, idx_t) override {
+      return out.printRaw(F("special prompt!"), len);
+    }
+};
+
+MENU(subMenu, "Sub-Menu", showEvent, anyEvent, noStyle
+     , OP("Sub1", showEvent, anyEvent)
+     , OP("Sub2", showEvent, anyEvent)
+     , OP("Sub3", showEvent, anyEvent)
+     , altOP(altPrompt, "", showEvent, anyEvent)
+     , EXIT("<Back")
+    );
+
+MENU(mainMenu, "Main menu", doNothing, noEvent, wrapStyle
+     , OP("Op1", action1, anyEvent)
+     , OP("Op2", action2, enterEvent)
+     /* FIELD Parameters :
+
+        Action Name(function name), Action Heading, Action Heading Unit,
+        range_lowest, range_highest, range_increment_step,
+        range_decrement_step
+     */
+     , FIELD(brightnessValue, "Brightness", "%", 0, 100, 5, 5, adjustBrightness, enterEvent, wrapStyle)
+     , SUBMENU(subMenu)
+     , SUBMENU(setLed)
+     , OP("LED On", internalLedOn, enterEvent) // will turn on built-in LED
+     , OP("LED Off", internalLedOff, enterEvent)// will turn off built-in LED
+     , SUBMENU(selMenu)
+     , SUBMENU(chooseMenu)
+     , OP("Alert test", doAlert, enterEvent)
+     , EXIT("<Back")
+    );
+
+
+
+//describing a menu output device without macros
+//define at least one panel for menu output
+const panel panels[] MEMMODE = {{0, 0, 128 / fontW, 64 / fontH}};
+navNode* nodes[sizeof(panels) / sizeof(panel)]; //navNodes to store navigation status
+panelsList pList(panels, nodes, 1); //a list of panels and nodes
+idx_t tops[MAX_DEPTH] = {0, 0}; //store cursor positions for each level
+
+#ifdef LARGE_FONT
+SSD1306AsciiOut outOLED(&oled, tops, pList, 8, 2); //oled output device menu driver
+
+#else
+SSD1306AsciiOut outOLED(&oled, tops, pList, 5, 1); //oled output device menu driver
+#endif
+
+menuOut* constMEM outputs[]  MEMMODE  = {&outOLED}; //list of output devices
+outputsList out(outputs, 1); //outputs list
+
+#ifdef NAV_BUTTONS_INPUT_PULLUP
+//build a map of keys to menu commands
+keyMap joystickBtn_map[] = {
+  { -BTN_SEL, defaultNavCodes[enterCmd].ch} ,
+  { -BTN_UP, defaultNavCodes[upCmd].ch} ,
+  { -BTN_DOWN, defaultNavCodes[downCmd].ch}  ,
+};
+keyIn<TOTAL_NAV_BUTTONS> joystickBtns(joystickBtn_map);//the input driver
+#else
+//build a map of keys to menu commands
+keyMap joystickBtn_map[] = {
+  { BTN_SEL, defaultNavCodes[enterCmd].ch} ,
+  { BTN_UP, defaultNavCodes[upCmd].ch} ,
+  { BTN_DOWN, defaultNavCodes[downCmd].ch}  ,
+};
+keyIn<TOTAL_NAV_BUTTONS> joystickBtns(joystickBtn_map);//the input driver
+#endif
+
+NAVROOT(nav, mainMenu, MAX_DEPTH, joystickBtns, out);
+
+result alert(menuOut& o, idleEvent e) {
+  if (e == idling) {
+    o.setCursor(0, 0);
+    o.print("alert test");
+    o.setCursor(0, 1);
+    o.print("press [select]");
+    o.setCursor(0, 2);
+    o.print("to continue...");
+  }
+  return proceed;
+}
+
+result doAlert(eventMask e, prompt &item) {
+  nav.idleOn(alert);
+  return proceed;
+}
+
+//when menu is suspended
+result idle(menuOut &o, idleEvent e) {
+  o.clear();
+  switch (e) {
+    case idleStart: o.println("suspending menu!"); break;
+    case idling: o.println("suspended..."); break;
+    case idleEnd: o.println("resuming menu."); break;
+  }
+  return proceed;
+}
+
+void setup() {
+  joystickBtns.begin();//
+  pinMode(LED_PIN, OUTPUT);
+  pinMode(LED_BUILTIN, OUTPUT);
+  Wire.begin();
+  oled.begin(&Adafruit128x64, OLED_I2C_ADDRESS); //check config
+  oled.setFont(menuFont);
+  oled.clear();
+  bool inv(true);
+  nav.idleTask = idle; //point a function to be used when menu is suspended
+}
+
+void loop() {
+  nav.poll();
+  delay(50);//simulate a delay when other tasks are done
+}

--- a/examples/SSD1306Ascii/Button_Navigation/config.h
+++ b/examples/SSD1306Ascii/Button_Navigation/config.h
@@ -1,0 +1,71 @@
+/*<CONGIGURATION FILE>*/
+
+/* List of Supported Fonts
+ *
+  Arial14,
+  Arial_bold_14,
+  Callibri11,
+  Callibri11_bold,
+  Callibri11_italic,
+  Callibri15,
+  Corsiva_12,
+  fixed_bold10x15,
+  font5x7,    //Do not use in LARGE_FONT, can use as default font
+  font8x8,
+  Iain5x7,    //Do not use in LARGE_FONT, can use as default font
+  lcd5x7,     //Do not use in LARGE_FONT, can use as default font
+  Stang5x7,   //Do not use in LARGE_FONT, can use as default font
+  System5x7,  //Do not use in LARGE_FONT, can use as default font
+  TimesNewRoman16,
+  TimesNewRoman16_bold,
+  TimesNewRoman16_italic,
+  utf8font10x16,
+  Verdana12,
+  Verdana12_bold,
+  Verdana12_italic,
+  X11fixed7x14,
+  X11fixed7x14B,
+  ZevvPeep8x16
+ *  
+ */
+
+#define OLED_I2C_ADDRESS 0x3C     //Defined OLED I2C Address
+
+/*
+ * Define your font from the list. 
+ * Default font: lcd5x7
+ * Comment out the following for using the default font.
+ */
+#define LARGE_FONT Arial14
+
+//Navigate buttons
+#define BTN_SEL     6                 // Select button
+#define BTN_UP      7                 // Up Button
+#define BTN_DOWN    8                 // Down Button
+
+// Comment the following to disable internal pullup for Navigate buttons
+//#define NAV_BUTTONS_INPUT_PULLUP
+
+#define TOTAL_NAV_BUTTONS 3       // Total Navigation Button used
+
+/*Demonstrate PWM with LED on D11*/
+#define LED_PIN 11                //Defined LED Pin to D11
+
+#define MAX_DEPTH 2
+
+#ifdef LOC
+// #define LARGE_FONT
+#define INV
+#endif
+ 
+ /*Do not change the values(recomended)*/
+#ifdef LARGE_FONT
+#define menuFont LARGE_FONT
+#define fontW 8
+#define fontH 16
+#else
+// #define menuFont System5x7
+#define menuFont lcd5x7
+#define fontW 5
+#define fontH 8
+#endif


### PR DESCRIPTION
This example demonstrates how can one use buttons to navigate around the menu displayed in an SSD1306 based Graphic display unit without Serial Communication required.