### PR TITLE
fix compile error for STM32

### DIFF
--- a/examples/SSD1306Ascii/Button_Navigation/Button_Navigation.ino
+++ b/examples/SSD1306Ascii/Button_Navigation/Button_Navigation.ino
@@ -151,7 +151,7 @@ MENU(mainMenu, "Main menu", doNothing, noEvent, wrapStyle
 
 //describing a menu output device without macros
 //define at least one panel for menu output
-const panel panels[] MEMMODE = {{0, 0, 128 / fontW, 64 / fontH}};
+constMEM panel panels[] MEMMODE = {{0, 0, 128 / fontW, 64 / fontH}};
 navNode* nodes[sizeof(panels) / sizeof(panel)]; //navNodes to store navigation status
 panelsList pList(panels, nodes, 1); //a list of panels and nodes
 idx_t tops[MAX_DEPTH] = {0, 0}; //store cursor positions for each level


### PR DESCRIPTION
It was not compiling for STM32 because of `const panel` in `line 154`. Had to change to `constMEM` to fix the compile error.