### PR TITLE
Generic RotaryEvent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ examples/screenNav
 /examples/dev
 /composition_test
 /examples/tiny
+
+**/.DS_Store

--- a/examples/rotaryEvent/rotaryEvent/rotaryEvent.ino
+++ b/examples/rotaryEvent/rotaryEvent/rotaryEvent.ino
@@ -1,0 +1,158 @@
+#include <menu.h>
+#include <menuIO/u8g2Out.h>
+#include <menuIO/chainStream.h>
+#include <menuIO/rotaryEventIn.h>
+
+// some example libraries to handle the rotation and clicky part
+// of the encoder. These will generate our events.
+#include <qdec.h> //https://github.com/SimpleHacks/QDEC
+#include <AceButton.h> // https://github.com/bxparks/AceButton
+
+
+// Encoder
+const int ROTARY_PIN_A    = 13; // the first pin connected to the rotary encoder
+const int ROTARY_PIN_B    = 15; // the second pin connected to the rotary encoder
+const int ROTARY_PIN_BUT  = 25;
+
+using namespace ::ace_button;
+using namespace ::SimpleHacks;
+QDecoder qdec(ROTARY_PIN_A, ROTARY_PIN_B, true); // rotary part
+AceButton button(ROTARY_PIN_BUT); // button part
+//--//
+
+
+// Display
+// LOLIN32 I2C SSD1306 128x64 display
+// https://github.com/olikraus/u8g2
+#define SDA 5
+#define SCL 4
+
+#include <Wire.h>
+#define fontName u8g2_font_7x13_mf
+#define fontX 7
+#define fontY 16
+#define offsetX 0
+#define offsetY 3
+#define U8_Width 128
+#define U8_Height 64
+#define USE_HWI2C
+#define fontMarginX 2
+#define fontMarginY 2
+U8G2_SSD1306_128X64_VCOMH0_F_HW_I2C u8g2(U8G2_R0, U8X8_PIN_NONE, SCL, SDA);//allow contrast change
+
+const colorDef<uint8_t> colors[6] MEMMODE={
+  {{0,0},{0,1,1}},//bgColor
+  {{1,1},{1,0,0}},//fgColor
+  {{1,1},{1,0,0}},//valColor
+  {{1,1},{1,0,0}},//unitColor
+  {{0,1},{0,0,1}},//cursorColor
+  {{1,1},{1,0,0}},//titleColor
+};
+//--//
+
+
+// AndroidMenu 
+// https://github.com/neu-rah/ArduinoMenu
+#define MAX_DEPTH 1
+
+unsigned int timeOn=10;
+unsigned int timeOff=90;
+
+using namespace Menu;
+MENU(mainMenu, "Blink menu", Menu::doNothing, Menu::noEvent, Menu::wrapStyle
+  ,FIELD(timeOn,"On","ms",0,1000,10,1, Menu::doNothing, Menu::noEvent, Menu::noStyle)
+  ,FIELD(timeOff,"Off","ms",0,10000,10,1,Menu::doNothing, Menu::noEvent, Menu::noStyle)
+  ,EXIT("<Back")
+);
+
+RotaryEventIn reIn(
+  RotaryEventIn::EventType::BUTTON_CLICKED | // select
+  RotaryEventIn::EventType::BUTTON_DOUBLE_CLICKED | // back
+  RotaryEventIn::EventType::BUTTON_LONG_PRESSED | // also back
+  RotaryEventIn::EventType::ROTARY_CCW | // up
+  RotaryEventIn::EventType::ROTARY_CW // down
+); // register capabilities, see AndroidMenu MenuIO/RotaryEventIn.h file
+MENU_INPUTS(in,&reIn);
+
+MENU_OUTPUTS(out,MAX_DEPTH
+  ,U8G2_OUT(u8g2,colors,fontX,fontY,offsetX,offsetY,{0,0,U8_Width/fontX,U8_Height/fontY})
+  ,NONE
+);
+NAVROOT(nav,mainMenu,MAX_DEPTH,in,out);
+//--//
+
+
+// This is the ISR (interrupt service routine) for rotary events
+// We will convert/relay events to the RotaryEventIn object
+// Callback config in setup()
+void IsrForQDEC(void) { 
+  QDECODER_EVENT event = qdec.update();
+  if (event & QDECODER_EVENT_CW) { reIn.registerEvent(RotaryEventIn::EventType::ROTARY_CW); }
+  else if (event & QDECODER_EVENT_CCW) { reIn.registerEvent(RotaryEventIn::EventType::ROTARY_CCW); }
+
+}
+
+// This is the handler/callback for button events
+// We will convert/relay events to the RotaryEventIn object
+// Callback config in setup()
+void handleButtonEvent(AceButton* /* button */, uint8_t eventType, uint8_t buttonState) {
+
+  switch (eventType) {
+    case AceButton::kEventClicked:
+      reIn.registerEvent(RotaryEventIn::EventType::BUTTON_CLICKED);
+      break;
+    case AceButton::kEventDoubleClicked:
+      reIn.registerEvent(RotaryEventIn::EventType::BUTTON_DOUBLE_CLICKED);
+      break;
+    case AceButton::kEventLongPressed:
+      reIn.registerEvent(RotaryEventIn::EventType::BUTTON_LONG_PRESSED);
+      break;
+  }
+}
+
+
+void setup() {
+  Serial.begin(115200);
+  while(!Serial);
+
+  // setup rotary encoder
+  pinMode(ROTARY_PIN_BUT, INPUT);
+  qdec.begin();
+  attachInterrupt(digitalPinToInterrupt(ROTARY_PIN_A), IsrForQDEC, CHANGE);
+  attachInterrupt(digitalPinToInterrupt(ROTARY_PIN_B), IsrForQDEC, CHANGE);
+
+  // setup rotary button
+  pinMode(ROTARY_PIN_BUT, INPUT);
+  ButtonConfig* buttonConfig = button.getButtonConfig();
+  buttonConfig->setEventHandler(handleButtonEvent);
+  buttonConfig->setFeature(ButtonConfig::kFeatureClick);
+  buttonConfig->setFeature(ButtonConfig::kFeatureDoubleClick);
+  buttonConfig->setFeature(ButtonConfig::kFeatureLongPress);
+
+  // setup OLED disaply
+  Wire.begin(SDA,SCL);
+  u8g2.begin();
+  u8g2.setFont(fontName);
+
+  do {
+    u8g2.drawStr(0,fontY,"RotaryEventIn demo");
+  } while(u8g2.nextPage());
+  // appear
+  for(int c=255;c>0;c--) {
+    u8g2.setContrast(255-255.0*log(c)/log(255));
+    delay(12);
+  }
+    
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+  button.check(); // acebutton check, rotary is on ISR
+  nav.doInput(); // menu check
+
+  if (nav.changed(0)) {//only draw if menu changed for gfx device
+    u8g2.firstPage();
+    do nav.doOutput(); while(u8g2.nextPage());
+  }
+
+}

--- a/examples/rotaryEvent/rotaryEvent/rotaryEvent.ino
+++ b/examples/rotaryEvent/rotaryEvent/rotaryEvent.ino
@@ -1,3 +1,23 @@
+/********************
+March 2020 M. Smit - github@gangkast.nl
+
+Generic Rotary/Button input
+output: SSD1306 OLED
+input: clickable rotary encoder
+
+purpose:
+
+  Having a generic rotary event-based implementation,
+  leaving rotary and button libraries up to the user.
+  Example uses QDEC and AceButton, but could be anything
+  that suits your particular hardware and/or needs.
+
+  TODO: userland rotary/button event mapping to menu actions,
+  as doubleclick/longpress are now hardcoded to back.
+  
+***/
+
+
 #include <menu.h>
 #include <menuIO/u8g2Out.h>
 #include <menuIO/chainStream.h>
@@ -116,7 +136,6 @@ void setup() {
   while(!Serial);
 
   // setup rotary encoder
-  pinMode(ROTARY_PIN_BUT, INPUT);
   qdec.begin();
   attachInterrupt(digitalPinToInterrupt(ROTARY_PIN_A), IsrForQDEC, CHANGE);
   attachInterrupt(digitalPinToInterrupt(ROTARY_PIN_B), IsrForQDEC, CHANGE);
@@ -128,6 +147,9 @@ void setup() {
   buttonConfig->setFeature(ButtonConfig::kFeatureClick);
   buttonConfig->setFeature(ButtonConfig::kFeatureDoubleClick);
   buttonConfig->setFeature(ButtonConfig::kFeatureLongPress);
+  buttonConfig->setFeature(ButtonConfig::kFeatureSuppressClickBeforeDoubleClick);
+  buttonConfig->setFeature(ButtonConfig::kFeatureSuppressAfterClick);
+  buttonConfig->setFeature(ButtonConfig::kFeatureSuppressAfterDoubleClick);
 
   // setup OLED disaply
   Wire.begin(SDA,SCL);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ArduinoMenu library
-version=4.19.1
+version=4.19.1-dev
 author=Rui Azevedo, ruihfazevedo@gmail.com
 maintainer=neu-rah, ruihfazevedo@gmail.com
 sentence=Generic menu/interactivity system

--- a/src/menuIO/rotaryEventIn.h
+++ b/src/menuIO/rotaryEventIn.h
@@ -51,7 +51,6 @@ template<class T> inline T& operator^= (T& a, T b) { return (T&)((int&)a ^= (int
         }
 
         void registerEvent(EventType e) {
-          //Serial.println("registerEvent");
           events |= e; // add it to the current events
         }
 

--- a/src/menuIO/rotaryEventIn.h
+++ b/src/menuIO/rotaryEventIn.h
@@ -1,0 +1,97 @@
+/* -*- C++ -*- */
+/**************
+
+RotaryEventIn.h
+
+March 2020
+
+quick and dirty input eventstream driver to accept events. You can use this
+stream to accept input from rotary encoders and/or buttons for example.
+
+***/
+
+
+// not sure where to put this..
+template<class T> inline T operator~ (T a) { return (T)~(int)a; }
+template<class T> inline T operator| (T a, T b) { return (T)((int)a | (int)b); }
+template<class T> inline T operator& (T a, T b) { return (T)((int)a & (int)b); }
+template<class T> inline T operator^ (T a, T b) { return (T)((int)a ^ (int)b); }
+template<class T> inline T& operator|= (T& a, T b) { return (T&)((int&)a |= (int)b); }
+template<class T> inline T& operator&= (T& a, T b) { return (T&)((int&)a &= (int)b); }
+template<class T> inline T& operator^= (T& a, T b) { return (T&)((int&)a ^= (int)b); }
+
+
+#ifndef __rotaryEventIn_h__
+  #define __rotaryEventIn_h__
+  #include "../menuDefs.h"
+
+  namespace Menu {
+
+    class RotaryEventIn:public menuIn {
+
+      public:
+
+        enum EventType {
+          BUTTON_CLICKED            = 1 << 0,
+          BUTTON_DOUBLE_CLICKED     = 1 << 1,
+          BUTTON_LONG_PRESSED       = 1 << 2,
+
+          ROTARY_CW                 = 1 << 3,
+          ROTARY_CCW                = 1 << 4,
+        };
+
+        EventType config;
+        EventType events;  // we could do a fifo if we miss events
+
+        RotaryEventIn(EventType c)
+          :config(c) {
+          // config for future use. we could raise if
+          // we are missing essential stuff
+          // and we need to absorb an arg anyway...
+        }
+
+        void registerEvent(EventType e) {
+          //Serial.println("registerEvent");
+          events |= e; // add it to the current events
+        }
+
+        int peek(void) override { return events; }
+        int available(void) override {return peek() != 0;}
+
+        int read() override {
+          // enterCmd
+          if (events & EventType::BUTTON_CLICKED) {
+            events &= ~EventType::BUTTON_CLICKED; // remove from events
+            return options->navCodes[enterCmd].ch;
+          }
+          // escCmd
+          else if (events & (EventType::BUTTON_DOUBLE_CLICKED|EventType::BUTTON_LONG_PRESSED)) {
+            events &= ~(EventType::BUTTON_DOUBLE_CLICKED|EventType::BUTTON_LONG_PRESSED); // remove
+            return options->navCodes[escCmd].ch;
+          }
+          // downCmd
+          else if (events & EventType::ROTARY_CW) {
+            events &= ~EventType::ROTARY_CW; // remove from events
+            return options->navCodes[upCmd].ch; // down sends up on menu? bug?
+          }
+          // upCmd
+          else if (events & EventType::ROTARY_CCW) {
+            events &= ~EventType::ROTARY_CCW; // remove from events
+            return options->navCodes[downCmd].ch; // up sends down on menu? bug?
+          }
+
+          else
+            return -1;
+        }
+
+        void flush() override {}
+        size_t write(uint8_t v) override {return 0;}
+
+    }; // class
+
+
+  }//namespace Menu
+
+
+
+#endif /* __rotaryEventIn_h__ */

--- a/src/menuIO/rotaryEventIn.h
+++ b/src/menuIO/rotaryEventIn.h
@@ -3,10 +3,16 @@
 
 RotaryEventIn.h
 
-March 2020
+March 2020 M. Smit - github@gangkast.nl
+Generic Rotary/Button input
 
-quick and dirty input eventstream driver to accept events. You can use this
-stream to accept input from rotary encoders and/or buttons for example.
+purpose:
+
+  Having a generic rotary event-based implementation,
+  leaving rotary and button libraries up to the user.
+
+  TODO: userland rotary/button event mapping to menu actions,
+  as doubleclick/longpress are now hardcoded to back.
 
 ***/
 


### PR DESCRIPTION
Hi there,

Ran into some trouble with the current ClickEncoder. Also love the 3rd party AceButton library for the configuration and tuning options. Also the QDEC rotary library works very well with my hardware.

So I needed an implementation for the rotary which is agnostic of the hardware libraries and the proposed version works pretty smooth. Included a working example with a rotary and an SSD1306 128x64 display. Sure there are things you can put into place. The code can also use some events->navcmd configuration in the future.

Cheers,
Martijn  