### PR TITLE
Add ESP32 WebMenu Compatibility

### DIFF
--- a/examples/esp8266_WebMenu/WebMenu/WebMenu.ino
+++ b/examples/esp8266_WebMenu/WebMenu/WebMenu.ino
@@ -43,10 +43,19 @@ so don't forget to change it.
 #endif
 //#include <menuIO/jsFmt.h>//to send javascript thru web socket (live update)
 #include <FS.h>
+#ifdef ESP8266
 #include <Hash.h>
 extern "C" {
   #include "user_interface.h"
 }
+#elif defined(ESP32)
+#include <SPIFFS.h>
+
+// Use external analogWrite library for ESP32 (optional)
+// for compatibility with older versions of espressif/arduino-esp32
+// https://github.com/Dlloydev/ESP32-ESP32S2-AnalogWrite
+#include <analogWrite.h>
+#endif
 
 using namespace Menu;
 
@@ -105,7 +114,11 @@ const char* serverName="192.168.1.79";
 #define HTTP_PORT 80
 #define WS_PORT 81
 #define USE_SERIAL Serial
+#ifdef ESP8266
 ESP8266WebServer server(80);
+#elif defined(ESP32)
+WebServer server(80);
+#endif
 WebSocketsServer webSocket(81);
 
 #define MAX_DEPTH 2

--- a/src/macros.h
+++ b/src/macros.h
@@ -10,12 +10,12 @@
     #define MENU_USERAM
   #endif
 #endif
-#if defined(ESP8266)
+#if defined(ESP8266) || defined(ESP32)
   #define MENU_ASYNC
   #define MENU_FMT_WRAPS
   #define MENU_IDLE_BKGND
 #endif
-#if defined(ESP8266) | defined(CORE_TEENSY)
+#if defined(ESP8266) || defined(CORE_TEENSY) || defined(ESP32)
   #define typeof(x) __typeof__(x)
 #endif
 #if defined(USE_PGM) || (defined(pgm_read_ptr_near) && !defined(MENU_USERAM))

--- a/src/menuIO/esp8266Out.h
+++ b/src/menuIO/esp8266Out.h
@@ -2,14 +2,19 @@
 
 #ifndef RSITE_ARDUINO_MENU_ESP8266OUT
   #define RSITE_ARDUINO_MENU_ESP8266OUT
-  #ifdef ESP8266
+  #if defined(ESP8266) || defined(ESP32)
     #include "../menuDefs.h"
+  #ifdef ESP8266
     #include <ESP8266WiFi.h>
+    #include <ESP8266WebServer.h>
+  #elif defined(ESP32)
+    #include <WiFi.h>
+    #include <WebServer.h>
+  #endif
     // based on WebServer:
     //   https://github.com/esp8266/Arduino/tree/master/libraries/ESP8266WebServer
     //   https://github.com/Links2004/arduinoWebSockets
     #include <WebSocketsServer.h>
-    #include <ESP8266WebServer.h>
     #include <vector>
     #include "xmlFmt.h"
 
@@ -61,6 +66,7 @@
 
       class esp8266_WebServerOut:public esp8266BufferedOut {
         public:
+#ifdef ESP8266
           ESP8266WebServer &server;
           //using esp8266Out::esp8266Out;
           esp8266_WebServerOut(
@@ -69,18 +75,38 @@
             idx_t* t,
             panelsList& p
           ):esp8266BufferedOut(t,p),server(srv) {}
+#elif defined(ESP32)
+          WebServer &server;
+          //using esp8266Out::esp8266Out;
+          esp8266_WebServerOut(
+            WebServer &srv,
+            /*const colorDef<esp8266Out::webColor> (&c)[nColors],*/
+            idx_t* t,
+            panelsList& p
+          ):esp8266BufferedOut(t,p),server(srv) {}
+#endif
           size_t write(uint8_t ch) override {response<<(char)ch;return 1;}
           // template<typename T> inline esp8266_WebServerOut& operator<<(T t) {response<<t;return *this;}
       };
 
       class esp8266_WebServerStreamOut:public esp8266Out {
         public:
+#ifdef ESP8266
           ESP8266WebServer &server;
           inline esp8266_WebServerStreamOut(
             ESP8266WebServer &srv,
             idx_t* t,
             panelsList& p
           ):esp8266Out(t,p),server(srv) {}
+#elif defined(ESP32)
+          WebServer &server;
+          inline esp8266_WebServerStreamOut(
+            WebServer &srv,
+            idx_t* t,
+            panelsList& p
+          ):esp8266Out(t,p),server(srv) {}
+#endif
+
           inline size_t write(uint8_t ch) override {
             char c[2]={ch,0};
             server.sendContent(c);

--- a/src/menuIO/esp8266Out.hpp
+++ b/src/menuIO/esp8266Out.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#ifdef ESP8266
+#if defined(ESP8266) || defined(ESP32)
   #include "../menuDefs.h"
   //MENU_FMT_WRAPS
   #include "esp8266Out.h"

--- a/src/menuIo.cpp
+++ b/src/menuIo.cpp
@@ -24,7 +24,7 @@ int noInput::peek() {return -1;}
 //
 ////////////////////////////////////////////////////////////////////////////////
 #if defined(MENU_DEBUG) || defined(MENU_ASYNC)
-  #ifdef ESP8266
+  #if defined(ESP8266) || defined(ESP32)
     template<typename T>
     menuOut& menuOut::operator<<(T o) {(*(Stream*)this)<<(o);return *this;}
   #endif

--- a/src/menuIo.h
+++ b/src/menuIo.h
@@ -83,7 +83,7 @@
         idx_t printText(const char* at,idx_t len);
         #if defined(MENU_DEBUG) || defined(MENU_ASYNC)
           virtual menuOut& operator<<(prompt const &p);
-          #ifdef ESP8266
+          #if defined(ESP8266) || defined(ESP32)
             template<typename T> menuOut& operator<<(T o);
           #endif
         #endif


### PR DESCRIPTION
Added flags where applicable for the ESP32 to extend support for WebMenu.
Tested successfully with a custom application on ESP32-WROOM32 (NodeMCU) and ESP32-PICO (TTGO-LoRa, TinyPICO).
~The included esp8266_WebMenu example has errors.~
Edit: Updated the esp8266_WebMenu example to work with ESP32