### PR TITLE
fix for issue #412

### DIFF
--- a/src/menuIO/rotaryEventIn.h
+++ b/src/menuIO/rotaryEventIn.h
@@ -18,13 +18,13 @@ purpose:
 
 
 // not sure where to put this..
-template<class T> inline T operator~ (T a) { return (T)~(int)a; }
-template<class T> inline T operator| (T a, T b) { return (T)((int)a | (int)b); }
-template<class T> inline T operator& (T a, T b) { return (T)((int)a & (int)b); }
-template<class T> inline T operator^ (T a, T b) { return (T)((int)a ^ (int)b); }
-template<class T> inline T& operator|= (T& a, T b) { return (T&)((int&)a |= (int)b); }
-template<class T> inline T& operator&= (T& a, T b) { return (T&)((int&)a &= (int)b); }
-template<class T> inline T& operator^= (T& a, T b) { return (T&)((int&)a ^= (int)b); }
+template<class T> constexpr inline T operator~ (T a) { return (T)~(int)a; }
+template<class T> constexpr inline T operator| (T a, T b) { return (T)((int)a | (int)b); }
+template<class T> constexpr inline T operator& (T a, T b) { return (T)((int)a & (int)b); }
+template<class T> constexpr inline T operator^ (T a, T b) { return (T)((int)a ^ (int)b); }
+template<class T> constexpr inline T& operator|= (T& a, T b) { return (T&)((int&)a |= (int)b); }
+template<class T> constexpr inline T& operator&= (T& a, T b) { return (T&)((int&)a &= (int)b); }
+template<class T> constexpr inline T& operator^= (T& a, T b) { return (T&)((int&)a ^= (int)b); }
 
 
 #ifndef __rotaryEventIn_h__
@@ -37,60 +37,60 @@ template<class T> inline T& operator^= (T& a, T b) { return (T&)((int&)a ^= (int
 
       public:
 
-        enum EventType {
-          BUTTON_CLICKED            = 1 << 0,
-          BUTTON_DOUBLE_CLICKED     = 1 << 1,
-          BUTTON_LONG_PRESSED       = 1 << 2,
+	enum EventType {
+	  BUTTON_CLICKED            = 1 << 0,
+	  BUTTON_DOUBLE_CLICKED     = 1 << 1,
+	  BUTTON_LONG_PRESSED       = 1 << 2,
 
-          ROTARY_CW                 = 1 << 3,
-          ROTARY_CCW                = 1 << 4,
-        };
+	  ROTARY_CW                 = 1 << 3,
+	  ROTARY_CCW                = 1 << 4,
+	};
 
-        EventType config;
-        EventType events;  // we could do a fifo if we miss events
+	EventType config;
+	EventType events;  // we could do a fifo if we miss events
 
-        RotaryEventIn(EventType c)
-          :config(c) {
-          // config for future use. we could raise if
-          // we are missing essential stuff
-          // and we need to absorb an arg anyway...
-        }
+	RotaryEventIn(EventType c)
+	  :config(c) {
+	  // config for future use. we could raise if
+	  // we are missing essential stuff
+	  // and we need to absorb an arg anyway...
+	}
 
-        void registerEvent(EventType e) {
-          events |= e; // add it to the current events
-        }
+	void registerEvent(EventType e) {
+	  events |= e; // add it to the current events
+	}
 
-        int peek(void) override { return events; }
-        int available(void) override {return peek() != 0;}
+	int peek(void) override { return events; }
+	int available(void) override {return peek() != 0;}
 
-        int read() override {
-          // enterCmd
-          if (events & EventType::BUTTON_CLICKED) {
-            events &= ~EventType::BUTTON_CLICKED; // remove from events
-            return options->navCodes[enterCmd].ch;
-          }
-          // escCmd
-          else if (events & (EventType::BUTTON_DOUBLE_CLICKED|EventType::BUTTON_LONG_PRESSED)) {
-            events &= ~(EventType::BUTTON_DOUBLE_CLICKED|EventType::BUTTON_LONG_PRESSED); // remove
-            return options->navCodes[escCmd].ch;
-          }
-          // downCmd
-          else if (events & EventType::ROTARY_CW) {
-            events &= ~EventType::ROTARY_CW; // remove from events
-            return options->navCodes[upCmd].ch; // down sends up on menu? bug?
-          }
-          // upCmd
-          else if (events & EventType::ROTARY_CCW) {
-            events &= ~EventType::ROTARY_CCW; // remove from events
-            return options->navCodes[downCmd].ch; // up sends down on menu? bug?
-          }
+	int read() override {
+	  // enterCmd
+	  if (events & EventType::BUTTON_CLICKED) {
+	    events &= ~EventType::BUTTON_CLICKED; // remove from events
+	    return options->navCodes[enterCmd].ch;
+	  }
+	  // escCmd
+	  else if (events & (EventType::BUTTON_DOUBLE_CLICKED|EventType::BUTTON_LONG_PRESSED)) {
+	    events &= ~(EventType::BUTTON_DOUBLE_CLICKED|EventType::BUTTON_LONG_PRESSED); // remove
+	    return options->navCodes[escCmd].ch;
+	  }
+	  // downCmd
+	  else if (events & EventType::ROTARY_CW) {
+	    events &= ~EventType::ROTARY_CW; // remove from events
+	    return options->navCodes[upCmd].ch; // down sends up on menu? bug?
+	  }
+	  // upCmd
+	  else if (events & EventType::ROTARY_CCW) {
+	    events &= ~EventType::ROTARY_CCW; // remove from events
+	    return options->navCodes[downCmd].ch; // up sends down on menu? bug?
+	  }
 
-          else
-            return -1;
-        }
+	  else
+	    return -1;
+	}
 
-        void flush() override {}
-        size_t write(uint8_t v) override {return 0;}
+	void flush() override {}
+	size_t write(uint8_t v) override {return 0;}
 
     }; // class
 


### PR DESCRIPTION
Fix for issue #412.

with this PR, enumerations can be safely combined using `|` overloaded operator, without causing linkage issue such as:

```
xxx.ino:117:1: error: variable 'saveConfigSubMenuShadows' with dynamic initialization put into program memory area
 MENU(saveConfigSubMenu, "Save config", Menu::doNothing, Menu::noEvent, Menu::noStyle | Menu::showTitle,
```

